### PR TITLE
added ability to transform points to screenspace when window resizes

### DIFF
--- a/examples/framebuffer.cpp
+++ b/examples/framebuffer.cpp
@@ -55,7 +55,8 @@ int main() {
     framebuffer_2.Draw(sprite);
 
     // Circle under user's mouse.
-    circle.SetPosition(window.input().cursor());
+    glm::vec2 mouse = window.ToScreenSpace(window.input().cursor());
+    circle.SetPosition(mouse);
     framebuffer_2.Draw(circle);
 
     // -------------------------------------------------------------------------

--- a/include/smk/Window.hpp
+++ b/include/smk/Window.hpp
@@ -55,6 +55,8 @@ class Window : public RenderTarget {
   // Returns true when the user wants to close the window.
   bool ShouldClose();
 
+  glm::vec2 ToScreenSpace(const glm::vec2& world);
+
   // Move-only ressource.
   Window(Window&&);
   Window(const Window&) = delete;
@@ -63,6 +65,7 @@ class Window : public RenderTarget {
 
  private:
   GLFWwindow* window_ = nullptr;
+  glm::vec2 initialSize_{}; // of the window
 
   // Time:
   float time_ = 0.f;

--- a/src/smk/Window.cpp
+++ b/src/smk/Window.cpp
@@ -107,6 +107,11 @@ void GLFWCharCallback(GLFWwindow* glfw_window, unsigned int codepoint) {
 
 }  // namespace
 
+glm::vec2 smk::Window::ToScreenSpace(const glm::vec2& world) {
+  glm::vec2 factor = glm::vec2(initialSize_.x/width_, initialSize_.y/height_);
+  return glm::vec2(world.x*factor.x, world.y*factor.y);
+}
+
 /// @brief A null window.
 Window::Window() {
   id_ = ++id;
@@ -123,6 +128,7 @@ Window::Window(int width, int height, const std::string& title) {
   window_by_id[id_] = this;
   width_ = width;
   height_ = height;
+  initialSize_ = {width, height};
 
   glfwSetErrorCallback(GLFWErrorCallback);
   // initialize the GLFW library
@@ -219,6 +225,7 @@ void Window::operator=(Window&& other) {
   std::swap(input_, other.input_);
   std::swap(id_, other.id_);
   std::swap(module_canvas_selector_, other.module_canvas_selector_);
+  std::swap(initialSize_, other.initialSize_);
   window_by_id[id_] = this;
   window_by_glfw_window[window_] = this;
 }


### PR DESCRIPTION
The window resizes but the mouse position returns values that is unusable for proper tracking. I added variables to track the initial window size and then provided a utility function to transform the input position to proper screen-space values that can be used after resizing.

I updated the framebuffer example to showcase this feature