### PR TITLE
Feature/coding standards

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ add_subdirectory(third_party)
 
 project(smk
   LANGUAGES CXX
-  VERSION 0.1.${smk_git_version}
+  VERSION 0.2.${smk_git_version}
 )
 
 add_library(smk STATIC

--- a/examples/bezier.cpp
+++ b/examples/bezier.cpp
@@ -10,7 +10,7 @@ int main() {
     window.PoolEvents();
     window.Clear(smk::Color::RGB(0.1f, 0.1f, 0.1f));
 
-    float y = 0.5 + 0.4 * sin(window.time());
+    float y = 0.5f + 0.4f * sin(window.time());
 
     // Draw a bezier path
     auto bezier = smk::Shape::Bezier(

--- a/examples/rounded_rectangle.cpp
+++ b/examples/rounded_rectangle.cpp
@@ -11,8 +11,8 @@ int main() {
     window.Clear(smk::Color::Black);
 
     smk::View view;
-    view.SetCenter(window.dimension() * 0.5f);
-    view.SetSize(window.dimension());
+    view.SetCenter(window.dimensions() * 0.5f);
+    view.SetSize(window.dimensions());
     window.SetView(view);
 
     float radius = std::min(window.width(), window.height()) * 0.5 *
@@ -21,7 +21,7 @@ int main() {
     auto rounded_rectangle = smk::Shape::RoundedRectangle(
         window.width() - margin, window.height() - margin, radius);
     rounded_rectangle.SetColor(smk::Color::Red);
-    rounded_rectangle.Move(window.dimension() * 0.5f);
+    rounded_rectangle.Move(window.dimensions() * 0.5f);
     window.Draw(rounded_rectangle);
 
     window.Display();

--- a/examples/scroll.cpp
+++ b/examples/scroll.cpp
@@ -10,11 +10,10 @@ int main() {
   auto window = smk::Window(480, 96, "smk/example/scroll");
   auto font = smk::Font(asset::arial_ttf, 34);
 
-  glm::vec2 scroll_sum{};
-
+  auto scroll_sum = glm::vec2(0.f, 0.f);
   window.ExecuteMainLoop([&] {
     window.PoolEvents();
-    scroll_sum += window.input().ScrollOffset();
+    scroll_sum += window.input().scroll_offset();
 
     window.Clear(smk::Color::Black);
     std::string x_scroll = std::to_string(scroll_sum.x);

--- a/include/smk/BlendMode.hpp
+++ b/include/smk/BlendMode.hpp
@@ -19,12 +19,12 @@ namespace smk {
 ///
 /// SMK provides 6 predefined common BlendMode:
 /// ~~~cpp
-/// smk::BlendMode::Replace;    // dst = src
-/// smk::BlendMode::Add;        // dst += src
-/// smk::BlendMode::Substract;  // dst -= src
-/// smk::BlendMode::Multiply;   // dst *= src
-/// smk::BlendMode::Alpha;      // dst = src * a + dest * (1 - a)
-/// smk::BlendMode::Invert;     // dst = 1 - dst
+/// smk::BlendMode::Replace;   // dst = src
+/// smk::BlendMode::Add;       // dst += src
+/// smk::BlendMode::Subtract; // dst -= src
+/// smk::BlendMode::Multiply;  // dst *= src
+/// smk::BlendMode::Alpha;     // dst = src * a + dest * (1 - a)
+/// smk::BlendMode::Invert;    // dst = 1 - dst
 /// ~~~
 ///
 /// ### Example:
@@ -61,12 +61,12 @@ namespace smk {
 /// ~~~
 struct BlendMode {
   // Preset of BlendMode:
-  static const BlendMode Replace;    // dst = src
-  static const BlendMode Add;        // dst += src
-  static const BlendMode Substract;  // dst -= src
-  static const BlendMode Multiply;   // dst *= src
-  static const BlendMode Alpha;      // dst = src * a + dest * (1 - a)
-  static const BlendMode Invert;     // dst = 1 - dst
+  static const BlendMode Replace;  // dst = src
+  static const BlendMode Add;      // dst += src
+  static const BlendMode Subtract; // dst -= src
+  static const BlendMode Multiply; // dst *= src
+  static const BlendMode Alpha;    // dst = src * a + dest * (1 - a)
+  static const BlendMode Invert;   // dst = 1 - dst
 
   // glBlendEquation
   GLenum equation_rgb = GL_FUNC_ADD;

--- a/include/smk/Color.hpp
+++ b/include/smk/Color.hpp
@@ -14,16 +14,16 @@ glm::vec4 RGBA(float red, float green, float blue, float alpha);
 glm::vec4 RGB(float red, float green, float blue);
 
 // Predefined colors.
-extern glm::vec4 White;
-extern glm::vec4 Black;
-extern glm::vec4 Grey;
-extern glm::vec4 Red;
-extern glm::vec4 Green;
-extern glm::vec4 Blue;
-extern glm::vec4 Yellow;
-extern glm::vec4 Magenta;
-extern glm::vec4 Cyan;
-extern glm::vec4 Transparent;
+extern const glm::vec4 White;
+extern const glm::vec4 Black;
+extern const glm::vec4 Grey;
+extern const glm::vec4 Red;
+extern const glm::vec4 Green;
+extern const glm::vec4 Blue;
+extern const glm::vec4 Yellow;
+extern const glm::vec4 Magenta;
+extern const glm::vec4 Cyan;
+extern const glm::vec4 Transparent;
 
 }  // namespace Color
 }  // namespace smk

--- a/include/smk/Font.hpp
+++ b/include/smk/Font.hpp
@@ -23,24 +23,24 @@ class Font {
   float line_height() const { return line_height_; }
   float baseline_position() const { return baseline_position_; }
 
-  struct Character {
+  struct Glyph {
     smk::Texture texture;
-    glm::ivec2 bearing;  // Offset from baseline to left/top of glyph
-    float advance;       // Offset to advance to next glyph
+    glm::ivec2 bearing = {0, 0};  // Offset from baseline to left/top of glyph
+    float advance = 0;            // Offset to advance to next glyph
   };
-  Character* GetCharacter(wchar_t);
+  Glyph* FetchGlyph(wchar_t in);
 
   // --- Move only resource ----------------------------------------------------
   Font(Font&&) = default;
   Font(const Font&) = delete;
-  void operator=(Font&&);
+  void operator=(Font&&) noexcept;
   void operator=(const Font&) = delete;
   // ---------------------------------------------------------------------------
 
  private:
-  void LoadCharacters(const std::vector<wchar_t>& chars);
+  void LoadGlyphs(const std::vector<wchar_t>& chars);
 
-  std::map<wchar_t, std::unique_ptr<Character>> characters_;
+  std::map<wchar_t, std::unique_ptr<Glyph>> glyphs_;
   std::string filename_;
   float line_height_ = 0.f;
   float baseline_position_ = 0.f;

--- a/include/smk/Framebuffer.hpp
+++ b/include/smk/Framebuffer.hpp
@@ -17,19 +17,20 @@ namespace smk {
 /// An off-screen drawable area. You can also draw it later in a smk::Sprite.
 class Framebuffer : public RenderTarget {
  public:
-  Framebuffer(int width, int height);
+  explicit Framebuffer(int width, int height);
   ~Framebuffer();
 
   // Move only ressource.
-  Framebuffer(Framebuffer&&);
+  Framebuffer(Framebuffer&&) noexcept;
   Framebuffer(const Framebuffer&) = delete;
-  void operator=(Framebuffer&&);
+  void operator=(Framebuffer&&) noexcept;
   void operator=(const Framebuffer&) = delete;
 
-  smk::Texture color_texture;
+  smk::Texture& color_texture();
 
  private:
   GLuint render_buffer_ = 0;
+  smk::Texture color_texture_;
 };
 
 }  // namespace smk

--- a/include/smk/Input.hpp
+++ b/include/smk/Input.hpp
@@ -49,7 +49,7 @@ class Input {
   /// @brief Whether a mouse button is down or not.
   /// @return true whenever a mouse button is hold.
   /// @param key The mouse button.
-  virtual bool IsMouseHold(int key) = 0;
+  virtual bool IsMouseHeld(int key) = 0;
   /// @brief Whether a mouse button is pressed or not.
   /// @return true whenever a mouse button is pressed.
   /// @param key The mouse button.
@@ -60,20 +60,21 @@ class Input {
   virtual bool IsMouseReleased(int key) = 0;
   /// @brief The mouse position.
   /// @return the mouse position.
-  virtual glm::vec2 mouse() = 0;
+  virtual glm::vec2 mouse() const = 0;
 
   // Touch.
   using FingerID = int;
+
   /// @brief The touch states.
   /// @return the touches states.
-  virtual std::map<FingerID, Touch>& touches() = 0;
+  virtual const std::map<FingerID, Touch>& touches() const = 0;
 
   // Cursor --------------------------------------------------------------------
   // A cursor is either the mouse or a touch. This is choosen smartly.
 
   /// @brief Whether the cursor is down or not.
   /// @return true whenever the cursor is down.
-  virtual bool IsCursorHold() = 0;
+  virtual bool IsCursorHeld() = 0;
   /// @brief Whether the cursor is pressed or not
   /// @return true whenever the cursor is pressed.
   virtual bool IsCursorPressed() = 0;
@@ -82,13 +83,13 @@ class Input {
   virtual bool IsCursorReleased() = 0;
   /// @brief The cursor position.
   /// @return the cursor position.
-  virtual glm::vec2 cursor() = 0;
+  virtual glm::vec2 cursor() const = 0;
 
   // Scroll -------------------------------------------------------------------
 
   /// @brief The mouse/touchpad scrolling offset since the last frame.
   /// @return the scrolling offset.
-  virtual glm::vec2 ScrollOffset() = 0;
+  virtual glm::vec2 scroll_offset() const = 0;
 
   // Character listener --------------------------------------------------------
   //
@@ -111,7 +112,7 @@ class Input {
   /// ~~~
   class CharacterListenerInterface {
    public:
-    virtual bool Receive(wchar_t*) = 0;
+    virtual bool Receive(wchar_t* in) = 0;
     virtual ~CharacterListenerInterface() = default;
   };
   using CharacterListener = std::unique_ptr<CharacterListenerInterface>;

--- a/include/smk/RenderState.hpp
+++ b/include/smk/RenderState.hpp
@@ -18,8 +18,8 @@ struct RenderState {
   ShaderProgram* shader_program = nullptr;  ///< The shader used.
   Texture texture;                          ///< The texture 0 bound.
   VertexArray vertex_array;                 ///< The shape to to be drawn
-  glm::mat4 view;                           ///< The "view" transformation.
-  glm::vec4 color;                          ///< The masking color.
+  glm::mat4 view = glm::mat4(1.f);          ///< The "view" transformation.
+  glm::vec4 color = glm::vec4(0.f);         ///< The masking color.
   BlendMode blend_mode = BlendMode::Alpha;  ///< The OpenGL BlendMode
 };
 

--- a/include/smk/RenderTarget.hpp
+++ b/include/smk/RenderTarget.hpp
@@ -25,10 +25,10 @@ struct RenderState;
 class RenderTarget {
  public:
   RenderTarget();
-  RenderTarget(RenderTarget&&);
-  RenderTarget(const RenderTarget&) = delete;
-  void operator=(RenderTarget&&);
-  void operator=(const RenderTarget& other) = delete;
+  RenderTarget(RenderTarget&& other) noexcept;
+  RenderTarget(const RenderTarget& rhs) = delete;
+  void operator=(RenderTarget&& other) noexcept;
+  void operator=(const RenderTarget& rhs) = delete;
 
   // 0. Clear the framebuffer
   void Clear(const glm::vec4& color);
@@ -36,25 +36,25 @@ class RenderTarget {
   // 1. Set the view
   void SetView(const View& view);
   void SetView(const glm::mat4& mat);
-  const View& GetView() const;
+  const View& view() const;
 
   // 2. Set a shader to render elements.
   void SetShaderProgram(ShaderProgram* shader_program);
-  ShaderProgram* shader_program_2d();
-  ShaderProgram* shader_program_3d();
+  ShaderProgram* shader_program_2d() const;
+  ShaderProgram* shader_program_3d() const;
 
   // 3. Draw some stuff.
-  virtual void Draw(const Drawable&);
-  virtual void Draw(const RenderState&);
+  virtual void Draw(const Drawable& drawable);
+  virtual void Draw(const RenderState& state);
 
   // Surface dimensions:
-  glm::vec2 dimension() const;
+  glm::vec2 dimensions() const;
   int width() const;
   int height() const;
 
   // Bind the OpenGL RenderFrame. This function is useless, because it is called
   // automatically for you. Use this only when you use direct OpenGL call.
-  static void Bind(RenderTarget*);
+  static void Bind(RenderTarget* target);
 
  protected:
   void InitRenderTarget();
@@ -63,7 +63,7 @@ class RenderTarget {
   int height_ = 0;
 
   // View:
-  glm::mat4 projection_matrix_;
+  glm::mat4 projection_matrix_ = glm::mat4(1);
   smk::View view_;
 
   // Shaders:
@@ -76,7 +76,7 @@ class RenderTarget {
   std::unique_ptr<ShaderProgram> shader_program_3d_;
 
   // Current shader program.
-  ShaderProgram* shader_program_;
+  ShaderProgram* shader_program_ = nullptr;
 
   GLuint frame_buffer_ = 0;
 };

--- a/include/smk/Shader.hpp
+++ b/include/smk/Shader.hpp
@@ -77,8 +77,8 @@ class Shader {
   // Wait until the Shader to be ready. Return true if it suceeded.
   bool CompileStatus();
 
-  // provide opengl shader identifiant.
-  GLuint GetHandle() const;
+  // Provide opengl shader identifiant.
+  GLuint id() const;
 
   ~Shader();
 
@@ -90,9 +90,9 @@ class Shader {
   // ---------------------------------------------------------------------------
 
  private:
-  Shader(std::vector<char> content, GLenum type);
+  Shader(const std::vector<char>& content, GLenum type);
   // opengl program identifier.
-  GLuint handle_ = 0;
+  GLuint id_ = 0;
 
   friend class ShaderProgram;
 };
@@ -126,7 +126,7 @@ class ShaderProgram {
   void Unuse() const;
 
   // provide the opengl identifiant
-  GLuint GetHandle() const;
+  GLuint id() const;
 
   // clang-format off
   // provide attributes informations.
@@ -163,7 +163,7 @@ class ShaderProgram {
   std::map<std::string, GLint> uniforms_;
 
   // opengl id
-  GLuint handle_ = 0;
+  GLuint id_ = 0;
 };
 
 }  // namespace smk

--- a/include/smk/Shape.hpp
+++ b/include/smk/Shape.hpp
@@ -20,7 +20,9 @@ namespace smk {
 class Shape {
  public:
   static Transformable FromVertexArray(VertexArray vertex_array);
-  static Transformable Line(glm::vec2 a, glm::vec2 b, float thickness);
+  static Transformable Line(const glm::vec2& a,
+                            const glm::vec2& b,
+                            float thickness);
   static Transformable Square();
   static Transformable Circle(float radius);
   static Transformable Circle(float radius, int subdivisions);

--- a/include/smk/Sound.hpp
+++ b/include/smk/Sound.hpp
@@ -43,15 +43,15 @@ class Sound {
   void SetVolume(float volume);
 
   // -- Move-only resource ---
-  Sound(Sound&&);
+  Sound(Sound&&) noexcept;
   Sound(const Sound&) = delete;
-  void operator=(Sound&&);
+  void operator=(Sound&&) noexcept;
   void operator=(const Sound&) = delete;
 
  private:
   const SoundBuffer* buffer_ = nullptr;
   unsigned int source_ = 0;
-  int is_playing_ = false;
+  bool is_playing_ = false;
 
   void EnsureSourceIsCreated();
 };

--- a/include/smk/SoundBuffer.hpp
+++ b/include/smk/SoundBuffer.hpp
@@ -33,20 +33,21 @@ class Sound;
 class SoundBuffer {
  public:
   SoundBuffer();  // Empty sound buffer
-  SoundBuffer(const std::string filename);
+  SoundBuffer(const std::string& filename);
 
   ~SoundBuffer();
 
-  void Play();
-
   // --- Move only resource ----------------------------------------------------
-  SoundBuffer(SoundBuffer&&);
+  SoundBuffer(SoundBuffer&&) noexcept;
   SoundBuffer(const SoundBuffer&) = delete;
-  void operator=(SoundBuffer&&);
+  void operator=(SoundBuffer&&) noexcept;
   void operator=(const SoundBuffer&) = delete;
   // ---------------------------------------------------------------------------
 
-  unsigned int buffer = 0;
+  unsigned int buffer() const;
+
+ private:
+  unsigned int buffer_ = 0;
 };
 }  // namespace smk
 

--- a/include/smk/Sprite.hpp
+++ b/include/smk/Sprite.hpp
@@ -36,7 +36,7 @@ class Sprite : public Transformable {
   Sprite() = default;
   Sprite(const Texture& texture);
   Sprite(const Texture& texture, const Rectangle rectangle);
-  Sprite(const Framebuffer& framebuffer);
+  explicit Sprite(Framebuffer& framebuffer);
 
   // Movable and copyable.
   Sprite(Sprite&&) = default;

--- a/include/smk/Text.hpp
+++ b/include/smk/Text.hpp
@@ -42,17 +42,17 @@ class Text : public Transformable {
   Text(Font& font, const std::wstring& text);
   virtual ~Text() = default;
 
-  void SetString(const std::wstring&);
-  void SetString(const std::string&);
+  void SetString(const std::wstring& wide_string);
+  void SetString(const std::string& string);
   void SetFont(Font& font);
 
-  virtual void Draw(RenderTarget& target, RenderState state) const override;
+  void Draw(RenderTarget& target, RenderState state) const override;
 
   glm::vec2 ComputeDimensions() const;
 
   Text(Text&&) = default;
   Text(const Text&) = default;
-  Text& operator=(Text&&) = default;
+  Text& operator=(Text&&) noexcept = default;
   Text& operator=(const Text&) = default;
 
  public:

--- a/include/smk/Texture.hpp
+++ b/include/smk/Texture.hpp
@@ -46,9 +46,9 @@ struct Texture {
 
   Texture();  // empty texture.
   Texture(const std::string& filename);
-  Texture(const std::string& filename, Option option);
+  Texture(const std::string& filename, const Option& option);
   Texture(const uint8_t* data, int width, int height);
-  Texture(const uint8_t* data, int width, int height, Option option);
+  Texture(const uint8_t* data, int width, int height, const Option& option);
   Texture(GLuint id, int width, int height);
   ~Texture();
 
@@ -61,19 +61,19 @@ struct Texture {
   operator bool() const { return id_ != 0; }
 
   // --- Copyable Movable resource ---------------------------------------------
-  Texture(Texture&&);
+  Texture(Texture&&) noexcept;
   Texture(const Texture&);
-  void operator=(Texture&&);
+  void operator=(Texture&&) noexcept;
   Texture& operator=(const Texture&);
   //----------------------------------------------------------------------------
   bool operator==(const Texture& other);
   bool operator!=(const Texture& other);
 
  private:
-  void Load(const uint8_t* data, int width, int height, Option option);
+  void Load(const uint8_t* data, int width, int height, const Option& option);
   GLuint id_ = 0;
-  int width_ = -1;
-  int height_ = -1;
+  int width_ = 0;
+  int height_ = 0;
 
   // Used to support copy. Nullptr as long as this class is not copied.
   // Otherwise an integer counting how many instances shares this resource.

--- a/include/smk/Touch.hpp
+++ b/include/smk/Touch.hpp
@@ -13,12 +13,12 @@ namespace smk {
 /// @example touch.cpp
 
 struct TouchDataPoint {
-  glm::vec2 position;
-  float time;
+  glm::vec2 position = {0, 0};
+  float time = 0.f;
 };
 
 struct Touch {
-  int finger_id;
+  int finger_id = 0;
   std::vector<TouchDataPoint> data_points;
 
   glm::vec2 position() const;

--- a/include/smk/Transformable.hpp
+++ b/include/smk/Transformable.hpp
@@ -21,7 +21,7 @@ class VertexArray;
 class TransformableBase : public Drawable {
  public:
   // Tranformation.
-  virtual glm::mat4 Transformation() const = 0;
+  virtual glm::mat4 transformation() const = 0;
 
   /// Color
   void SetColor(const glm::vec4& color);
@@ -37,22 +37,22 @@ class TransformableBase : public Drawable {
 
   // VertexArray
   void SetVertexArray(VertexArray vertex_array);
-  const VertexArray vertex_array() const { return vertex_array_; }
+  const VertexArray& vertex_array() const { return vertex_array_; }
 
   // Drawable override
-  virtual void Draw(RenderTarget& target, RenderState state) const override;
+  void Draw(RenderTarget& target, RenderState state) const override;
 
   // Movable-copyable class.
   TransformableBase() = default;
-  TransformableBase(TransformableBase&&) = default;
+  TransformableBase(TransformableBase&&) noexcept = default;
   TransformableBase(const TransformableBase&) = default;
-  TransformableBase& operator=(TransformableBase&&) = default;
+  TransformableBase& operator=(TransformableBase&&) noexcept = default;
   TransformableBase& operator=(const TransformableBase&) = default;
 
  private:
   glm::vec4 color_ = {1.0, 1.0, 1.0, 1.0};
   Texture texture_;
-  BlendMode blend_mode_;
+  BlendMode blend_mode_ = BlendMode::Alpha;
   VertexArray vertex_array_;
 };
 
@@ -67,13 +67,13 @@ class Transformable : public TransformableBase {
 
   // Center
   void SetCenter(float center_x, float center_y);
-  void SetCenter(glm::vec2);
+  void SetCenter(const glm::vec2& center);
 
   // Position
-  void Move(glm::vec2 move);
+  void Move(const glm::vec2& move);
   void Move(float x, float y);
   void SetPosition(float x, float y);
-  void SetPosition(glm::vec2 position);
+  void SetPosition(const glm::vec2& position);
 
   // Rotation
   void Rotate(float rotation);
@@ -81,17 +81,17 @@ class Transformable : public TransformableBase {
 
   // Scale
   void SetScale(float scale);
-  void SetScale(glm::vec2 scale);
+  void SetScale(const glm::vec2& scale);
   void SetScale(float scale_x, float scale_y);
   void SetScaleX(float scale_x);
   void SetScaleY(float scale_y);
 
   // Transformable override;
-  glm::mat4 Transformation() const override;
+  glm::mat4 transformation() const override;
 
   // Movable-copyable class.
   Transformable() = default;
-  Transformable(Transformable&&) = default;
+  Transformable(Transformable&&) noexcept = default;
   Transformable(const Transformable&) = default;
   Transformable& operator=(Transformable&&) = default;
   Transformable& operator=(const Transformable&) = default;
@@ -112,8 +112,8 @@ class Transformable3D : public TransformableBase {
  public:
   virtual ~Transformable3D() = default;
 
-  void SetTransformation(const glm::mat4);
-  glm::mat4 Transformation() const override;
+  void SetTransformation(const glm::mat4& mat);
+  glm::mat4 transformation() const override;
 
   // Movable-copyable class.
   Transformable3D() = default;

--- a/include/smk/Vertex.hpp
+++ b/include/smk/Vertex.hpp
@@ -11,17 +11,17 @@ namespace smk {
 
 /// The vertex structure suitable for a 2D shader.
 struct Vertex2D {
-  glm::vec2 space_position;
-  glm::vec2 texture_position;
+  glm::vec2 space_position = {0.f, 0.f};
+  glm::vec2 texture_position = {0.f, 0.f};
 
   static void Bind();
 };
 
 /// The vertex structure suitable for a 2D shader.
 struct Vertex3D {
-  glm::vec3 space_position;
-  glm::vec3 normal;
-  glm::vec2 texture_position;
+  glm::vec3 space_position = {0.f, 0.f, 0.f};
+  glm::vec3 normal = {0.f, 0.f, 0.f};
+  glm::vec2 texture_position = {0.f, 0.f};
 
   static void Bind();
 };

--- a/include/smk/VertexArray.hpp
+++ b/include/smk/VertexArray.hpp
@@ -29,22 +29,22 @@ class VertexArray {
   void UnBind() const;
 
   // --- Movable-Copyable resource ---------------------------------------------
-  VertexArray(VertexArray&&);
+  VertexArray(VertexArray&&) noexcept;
   VertexArray(const VertexArray&);
-  VertexArray& operator=(VertexArray&&);
+  VertexArray& operator=(VertexArray&&) noexcept;
   VertexArray& operator=(const VertexArray&);
   // ---------------------------------------------------------------------------
   bool operator==(const smk::VertexArray&) const;
   bool operator!=(const smk::VertexArray&) const;
 
-  int size() const;
+  size_t size() const;
 
  private:
   void Allocate(int element_size, void* data);
 
   GLuint vbo_ = 0;
   GLuint vao_ = 0;
-  int size_ = 0;
+  size_t size_ = 0u;
 
   // Used to support copy. Nullptr as long as this class is not copied.
   // Otherwise an integer counting how many instances shares this resource.

--- a/include/smk/View.hpp
+++ b/include/smk/View.hpp
@@ -14,9 +14,9 @@ namespace smk {
 class View {
  public:
   void SetCenter(float x, float y);
-  void SetCenter(glm::vec2 center);
+  void SetCenter(const glm::vec2& center);
   void SetSize(float width, float height);
-  void SetSize(glm::vec2 size);
+  void SetSize(const glm::vec2& size);
 
   float Left() const { return x_ - width_ / 2; };     /// <
   float Right() const { return x_ + width_ / 2; };    /// <
@@ -24,10 +24,10 @@ class View {
   float Bottom() const { return y_ + height_ / 2; };  /// <
 
  public:
-  float x_ = 0;
-  float y_ = 0;
-  float width_ = 0;
-  float height_ = 0;
+  float x_ = 0.f;
+  float y_ = 0.f;
+  float width_ = 0.f;
+  float height_ = 0.f;
 };
 
 }  // namespace smk

--- a/include/smk/Window.hpp
+++ b/include/smk/Window.hpp
@@ -56,9 +56,9 @@ class Window : public RenderTarget {
   bool ShouldClose();
 
   // Move-only ressource.
-  Window(Window&&);
+  Window(Window&&) noexcept;
   Window(const Window&) = delete;
-  void operator=(Window&&);
+  void operator=(Window&&) noexcept;
   void operator=(const Window&) = delete;
 
  private:
@@ -71,7 +71,7 @@ class Window : public RenderTarget {
   void UpdateDimensions();
 
   std::unique_ptr<InputImpl> input_;
-  int id_;
+  int id_ = 0;
 
   std::string module_canvas_selector_;
 };

--- a/src/smk/BlendMode.cpp
+++ b/src/smk/BlendMode.cpp
@@ -17,7 +17,7 @@ const BlendMode BlendMode::Add = {
 };
 
 /// @brief destination -= source.
-const BlendMode BlendMode::Substract = {
+const BlendMode BlendMode::Subtract = {
     GL_FUNC_REVERSE_SUBTRACT,
     GL_FUNC_REVERSE_SUBTRACT,
     GL_ONE,
@@ -27,7 +27,7 @@ const BlendMode BlendMode::Substract = {
 };
 
 /// @brief destination = source * source.a + destination * (1 - souce.a)
-const BlendMode BlendMode::Alpha{
+const BlendMode BlendMode::Alpha = {
     GL_FUNC_ADD,  GL_FUNC_ADD,
     GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA,
     GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA,

--- a/src/smk/Color.cpp
+++ b/src/smk/Color.cpp
@@ -28,16 +28,16 @@ glm::vec4 RGB(float red, float green, float blue) {
 }
 
 // clang-format off
-glm::vec4 White       = glm::vec4(1.f, 1.f, 1.f, 1.f); ///< White
-glm::vec4 Black       = glm::vec4(0.f, 0.f, 0.f, 1.f); ///< Black
-glm::vec4 Grey        = glm::vec4(.5f, .5f, .5f, 1.f); ///< Grey
-glm::vec4 Red         = glm::vec4(1.f, 0.f, 0.f, 1.f); ///< Red
-glm::vec4 Green       = glm::vec4(0.f, 1.f, 0.f, 1.f); ///< Green
-glm::vec4 Blue        = glm::vec4(0.f, 0.f, 1.f, 1.f); ///< Blue
-glm::vec4 Yellow      = glm::vec4(1.f, 1.f, 0.f, 1.f); ///< Yellow
-glm::vec4 Magenta     = glm::vec4(1.f, 0.f, 1.f, 1.f); ///< Magenta
-glm::vec4 Cyan        = glm::vec4(0.f, 1.f, 1.f, 1.f); ///< Cyan
-glm::vec4 Transparent = glm::vec4(0.f, 0.f, 0.f, 0.f); ///< Transparent
+const glm::vec4 White       = {1.f, 1.f, 1.f, 1.f}; ///< White
+const glm::vec4 Black       = {0.f, 0.f, 0.f, 1.f}; ///< Black
+const glm::vec4 Grey        = {.5f, .5f, .5f, 1.f}; ///< Grey
+const glm::vec4 Red         = {1.f, 0.f, 0.f, 1.f}; ///< Red
+const glm::vec4 Green       = {0.f, 1.f, 0.f, 1.f}; ///< Green
+const glm::vec4 Blue        = {0.f, 0.f, 1.f, 1.f}; ///< Blue
+const glm::vec4 Yellow      = {1.f, 1.f, 0.f, 1.f}; ///< Yellow
+const glm::vec4 Magenta     = {1.f, 0.f, 1.f, 1.f}; ///< Magenta
+const glm::vec4 Cyan        = {0.f, 1.f, 1.f, 1.f}; ///< Cyan
+const glm::vec4 Transparent = {0.f, 0.f, 0.f, 0.f}; ///< Transparent
 // clang-format on
 
 }  // namespace Color

--- a/src/smk/Framebuffer.cpp
+++ b/src/smk/Framebuffer.cpp
@@ -53,7 +53,7 @@ Framebuffer::Framebuffer(int width, int height) {
 
   InitRenderTarget();
 
-  color_texture = smk::Texture(id, width_, height_);
+  color_texture_ = smk::Texture(id, width_, height_);
 }
 
 Framebuffer::~Framebuffer() {
@@ -68,14 +68,18 @@ Framebuffer::~Framebuffer() {
   }
 }
 
-Framebuffer::Framebuffer(Framebuffer&& other) {
+Framebuffer::Framebuffer(Framebuffer&& other) noexcept {
   this->operator=(std::move(other));
 }
 
-void Framebuffer::operator=(Framebuffer&& other) {
+void Framebuffer::operator=(Framebuffer&& other) noexcept {
   RenderTarget::operator=(std::move(other));
-  std::swap(color_texture, other.color_texture);
+  std::swap(color_texture_, other.color_texture_);
   std::swap(render_buffer_, other.render_buffer_);
+}
+
+smk::Texture& Framebuffer::color_texture() {
+  return color_texture_;
 }
 
 }  // namespace smk

--- a/src/smk/InputImpl.cpp
+++ b/src/smk/InputImpl.cpp
@@ -68,7 +68,10 @@ void InputImpl::OnTouchEvent(int eventType,
 
     if (eventType == EMSCRIPTEN_EVENT_TOUCHSTART ||
         eventType == EMSCRIPTEN_EVENT_TOUCHMOVE) {
-      auto data = TouchDataPoint{glm::vec2(touch.targetX, touch.targetY), 0.f};
+      TouchDataPoint data = {
+          glm::vec2(touch.targetX, touch.targetY),
+          0.f,
+      };
       auto& internal_touch = touches_[touch.identifier];
       internal_touch.finger_id = touch.identifier;
       internal_touch.data_points.push_back(data);
@@ -111,32 +114,35 @@ bool InputImpl::IsMouseReleased(int key) {
   return ((p.first == GLFW_RELEASE) && (p.second == GLFW_PRESS));
 }
 
-glm::vec2 InputImpl::mouse() {
+glm::vec2 InputImpl::mouse() const {
   return mouse_;
 }
 
-std::map<Input::FingerID, Touch>& InputImpl::touches() {
+const std::map<Input::FingerID, Touch>& InputImpl::touches() const {
   return touches_;
 }
 
-bool InputImpl::IsMouseHold(int key) {
+bool InputImpl::IsMouseHeld(int key) {
   auto p = mouse_state_[key];
   return (p.first == GLFW_PRESS);
 }
 
-bool InputImpl::IsCursorHold() {
+bool InputImpl::IsCursorHeld() {
   return cursor_press_ && cursor_press_previous_;
 }
+
 bool InputImpl::IsCursorPressed() {
   return cursor_press_ && !cursor_press_previous_;
 }
+
 bool InputImpl::IsCursorReleased() {
   return !cursor_press_ && cursor_press_previous_;
 }
-glm::vec2 InputImpl::cursor() {
+
+glm::vec2 InputImpl::cursor() const {
   return cursor_;
 }
-glm::vec2 InputImpl::ScrollOffset() {
+glm::vec2 InputImpl::scroll_offset() const {
   return scroll_old_;
 }
 

--- a/src/smk/InputImpl.hpp
+++ b/src/smk/InputImpl.hpp
@@ -33,14 +33,14 @@ class InputImpl : public Input {
   bool IsKeyHold(int key) override;
   bool IsMousePressed(int key) override;
   bool IsMouseReleased(int key) override;
-  glm::vec2 mouse() override;
-  std::map<FingerID, Touch>& touches() override;
-  bool IsMouseHold(int key) override;
-  bool IsCursorHold() override;
+  glm::vec2 mouse() const override;
+  const std::map<FingerID, Touch>& touches() const override;
+  bool IsMouseHeld(int key) override;
+  bool IsCursorHeld() override;
   bool IsCursorPressed() override;
   bool IsCursorReleased() override;
-  glm::vec2 cursor() override;
-  glm::vec2 ScrollOffset() override;
+  glm::vec2 cursor() const override;
+  glm::vec2 scroll_offset() const override;
   CharacterListener MakeCharacterListener() override;
 
  private:
@@ -49,20 +49,20 @@ class InputImpl : public Input {
 
   // Mouse.
   std::map<int, std::pair<int, int>> mouse_state_;
-  glm::vec2 mouse_;
+  glm::vec2 mouse_ = {0.f, 0.f};
 
   // Touch.
   std::map<FingerID, Touch> touches_;
 
   // Cursor
-  glm::vec2 cursor_;
+  glm::vec2 cursor_ = {0, 0};
   bool cursor_press_ = false;
   bool cursor_press_previous_ = false;
   bool touching_ = true;
 
   // Scroll
-  glm::vec2 scroll_ = glm::vec2(0.f, 0.f);
-  glm::vec2 scroll_old_ = glm::vec2(0.f, 0.f);
+  glm::vec2 scroll_ = {0.f, 0.f};
+  glm::vec2 scroll_old_ = {0.f, 0.f};
 
   // CharacterListener
   std::unordered_set<CharacterListenerImpl*> character_listeners_;

--- a/src/smk/Shape.cpp
+++ b/src/smk/Shape.cpp
@@ -22,9 +22,12 @@ Transformable Shape::FromVertexArray(VertexArray vertex_array) {
 /// @param a The first end.
 /// @param b Second end.
 /// @param thickness This line thickness.
-Transformable Shape::Line(glm::vec2 a, glm::vec2 b, float thickness) {
+Transformable Shape::Line(const glm::vec2& a,
+                          const glm::vec2& b,
+                          float thickness) {
   glm::vec2 dt =
       glm::normalize(glm::vec2(b.y - a.y, -b.x + a.x)) * thickness * 0.5f;
+
   return FromVertexArray(VertexArray({
       {a + dt, {0.f, 0.f}},
       {b + dt, {1.f, 0.f}},
@@ -38,6 +41,7 @@ Transformable Shape::Line(glm::vec2 a, glm::vec2 b, float thickness) {
 /// @brief Return the square [0,1]x[0,1]
 Transformable Shape::Square() {
   static VertexArray vertex_array;
+
   if (!vertex_array.size()) {
     vertex_array = VertexArray({
         {{0.f, 0.f}, {0.f, 0.f}},
@@ -49,7 +53,7 @@ Transformable Shape::Square() {
     });
   }
 
-  return FromVertexArray(VertexArray(vertex_array));
+  return FromVertexArray(vertex_array);
 }
 
 /// @brief Return a circle.
@@ -193,7 +197,7 @@ std::vector<glm::vec2> Shape::Bezier(const std::vector<glm::vec2>& points,
     std::vector<glm::vec2> data = points;
     float x = float(index) / subdivision;
     while (data.size() >= 2) {
-      for (size_t i = 0; i < points.size() - 1; ++i)
+      for (size_t i = 0; i < data.size() - 1; ++i)
         data[i] = glm::mix(data[i], data[i + 1], x);
       data.resize(data.size() - 1);
     }
@@ -283,13 +287,12 @@ smk::Transformable Shape::Path(const std::vector<glm::vec2>& points,
     glm::vec2& C = points_left[i];
     glm::vec2& D = points_right[i];
 
-    v.push_back(smk::Vertex{A, {0.0, 0.0}});
-    v.push_back(smk::Vertex{B, {0.0, 0.0}});
-    v.push_back(smk::Vertex{D, {0.0, 0.0}});
-
-    v.push_back(smk::Vertex{A, {0.0, 0.0}});
-    v.push_back(smk::Vertex{D, {0.0, 0.0}});
-    v.push_back(smk::Vertex{C, {0.0, 0.0}});
+    v.push_back({A, {0.0, 0.0}});
+    v.push_back({B, {0.0, 0.0}});
+    v.push_back({D, {0.0, 0.0}});
+    v.push_back({A, {0.0, 0.0}});
+    v.push_back({D, {0.0, 0.0}});
+    v.push_back({C, {0.0, 0.0}});
   }
 
   return smk::Shape::FromVertexArray(smk::VertexArray(std::move(v)));

--- a/src/smk/Sound.cpp
+++ b/src/smk/Sound.cpp
@@ -45,12 +45,12 @@ Sound::~Sound() {
 
 /// @brief Start playing the sound.
 void Sound::Play() {
-  if (!buffer_ || !buffer_->buffer)
+  if (!buffer_ || !buffer_->buffer())
     return;
   if (is_playing_)
     Stop();
   EnsureSourceIsCreated();
-  alSourcei(source_, AL_BUFFER, buffer_->buffer);
+  alSourcei(source_, AL_BUFFER, buffer_->buffer());
   alSourcePlay(source_);
   is_playing_ = true;
 }
@@ -80,11 +80,11 @@ bool Sound::IsPlaying() {
   return (state == AL_PLAYING);
 }
 
-Sound::Sound(Sound&& o) {
+Sound::Sound(Sound&& o) noexcept {
   operator=(std::move(o));
 }
 
-void Sound::operator=(Sound&& o) {
+void Sound::operator=(Sound&& o) noexcept {
   std::swap(buffer_, o.buffer_);
   std::swap(source_, o.source_);
   std::swap(is_playing_, o.is_playing_);

--- a/src/smk/SoundBuffer.cpp
+++ b/src/smk/SoundBuffer.cpp
@@ -17,7 +17,7 @@ namespace smk {
 SoundBuffer::SoundBuffer() {}
 
 /// @brief Load a sound resource into memory from a file.
-SoundBuffer::SoundBuffer(const std::string filename) : SoundBuffer() {
+SoundBuffer::SoundBuffer(const std::string& filename) : SoundBuffer() {
   if (!Audio::Initialized()) {
     static bool once = true;
     if (once) {
@@ -53,8 +53,8 @@ SoundBuffer::SoundBuffer(const std::string filename) : SoundBuffer() {
   }
   // clang-format on.
 
-  alGenBuffers(1, &buffer);
-  alBufferData(buffer, format, data.data(), data.size() * sizeof(ALshort), sample_rate);
+  alGenBuffers(1, &buffer_);
+  alBufferData(buffer_, format, data.data(), data.size() * sizeof(ALshort), sample_rate);
 
   if (alGetError() != AL_NO_ERROR) {
     std::cerr << "SoundBuffer: OpenAL error" << std::endl;
@@ -63,16 +63,21 @@ SoundBuffer::SoundBuffer(const std::string filename) : SoundBuffer() {
 }
 
 SoundBuffer::~SoundBuffer() {
-  if (buffer)
-    alDeleteBuffers(1, &buffer);
+  if (buffer_)
+    alDeleteBuffers(1, &buffer_);
 }
 
-SoundBuffer::SoundBuffer(SoundBuffer&& o) {
+SoundBuffer::SoundBuffer(SoundBuffer&& o) noexcept {
   this->operator=(std::move(o));
 }
 
-void SoundBuffer::operator=(SoundBuffer&& o) {
-  std::swap(buffer, o.buffer);
+void SoundBuffer::operator=(SoundBuffer&& o) noexcept {
+  std::swap(buffer_, o.buffer_);
+}
+
+unsigned int SoundBuffer::buffer() const
+{
+  return buffer_;
 }
 
 }  // namespace smk

--- a/src/smk/Sprite.cpp
+++ b/src/smk/Sprite.cpp
@@ -27,14 +27,14 @@ Sprite::Sprite(const Texture& texture, const Rectangle rectangle) {
 
 /// @brief A sprite for drawing the content of a Framebuffer.
 /// @param framebuffer The framebuffer to be used.
-Sprite::Sprite(const Framebuffer& framebuffer) {
-  Transformable::SetTexture(framebuffer.color_texture);
+Sprite::Sprite(Framebuffer& framebuffer) {
+  Transformable::SetTexture(framebuffer.color_texture());
   float l = 0.f;
   float r = 1.f;
   float t = 0.f;
   float b = 1.f;
-  float www = framebuffer.color_texture.width();
-  float hhh = framebuffer.color_texture.height();
+  float www = framebuffer.color_texture().width();
+  float hhh = framebuffer.color_texture().height();
   SetVertexArray(VertexArray(std::vector<Vertex>({
       {{0.f, 0.f}, {l, b}},
       {{0.f, hhh}, {l, t}},

--- a/src/smk/StbImage.cpp
+++ b/src/smk/StbImage.cpp
@@ -3554,7 +3554,7 @@ static stbi_uc* bmp_load(stbi* s, int* x, int* y, int* comp, int req_comp) {
   }
   if (flip_vertically) {
     stbi_uc t;
-    for (j = 0; j < (((int)s->img_y) >> 1); ++j) {
+    for (j = 0; j < ((int)s->img_y >> 1); ++j) {
       stbi_uc* p1 = out + j * s->img_x * target;
       stbi_uc* p2 = out + (s->img_y - 1 - j) * s->img_x * target;
       for (i = 0; i < (int)s->img_x * target; ++i) {

--- a/src/smk/Text.cpp
+++ b/src/smk/Text.cpp
@@ -43,13 +43,13 @@ Text::Text(Font& font, const std::wstring& text) : Text(font) {
 }
 
 /// Update the text to be drawn.
-void Text::SetString(const std::wstring& s) {
-  string_ = s;
+void Text::SetString(const std::wstring& wide_string) {
+  string_ = wide_string;
 }
 
 /// Update the text to be drawn.
-void Text::SetString(const std::string& s) {
-  string_ = to_wstring(s);
+void Text::SetString(const std::string& string) {
+  string_ = to_wstring(string);
 }
 
 /// Update the Font to be used.
@@ -60,7 +60,7 @@ void Text::SetFont(Font& font) {
 /// Draw the Text to the screen.
 void Text::Draw(RenderTarget& target, RenderState state) const {
   state.color *= color();
-  glm::mat4 transformation = state.view * Transformation();
+  glm::mat4 transformation = state.view * this->transformation();
   float advance_x = 0.f;
   float advance_y = font_->baseline_position();
 
@@ -80,7 +80,7 @@ void Text::Draw(RenderTarget& target, RenderState state) const {
       continue;
     }
 
-    auto character = font_->GetCharacter(it);
+    auto character = font_->FetchGlyph(it);
     if (!character)
       continue;
 
@@ -116,7 +116,7 @@ glm::vec2 Text::ComputeDimensions() const {
       dimension.y += font_->line_height();
       continue;
     }
-    auto character = font_->GetCharacter(it);
+    auto character = font_->FetchGlyph(it);
     if (!character)
       continue;
     advance_x += character->advance;

--- a/src/smk/Texture.cpp
+++ b/src/smk/Texture.cpp
@@ -10,7 +10,7 @@
 #include "StbImage.hpp"
 
 namespace smk {
-extern bool invalidate_texture;
+extern bool g_invalidate_textures;
 
 int next_power_of_2(int v) {
   return v;
@@ -31,7 +31,7 @@ Texture::Texture(const std::string& filename) : Texture(filename, Option()) {}
 /// @brief Load a texture from a file.
 /// @param filename The file name of the image to be loaded.
 /// @param option Additionnal option (texture wrap, min filter, mag filter, ...)
-Texture::Texture(const std::string& filename, Option option) {
+Texture::Texture(const std::string& filename, const Option& option) {
   FILE* file = fopen(filename.c_str(), "rb");
   if (!file) {
     std::cerr << "File " << filename << " not found" << std::endl;
@@ -70,14 +70,20 @@ Texture::Texture(const uint8_t* data, int width, int height)
 /// @param width the image's with.
 /// @param height the image's height.
 /// @param option Additionnal option (texture wrap, min filter, mag filter, ...)
-Texture::Texture(const uint8_t* data, int width, int height, Option option)
+Texture::Texture(const uint8_t* data,
+                 int width,
+                 int height,
+                 const Option& option)
     : Texture() {
   width_ = width;
   height_ = height;
   Load(data, width_, height_, option);
 }
 
-void Texture::Load(const uint8_t* data, int width, int height, Option option) {
+void Texture::Load(const uint8_t* data,
+                   int width,
+                   int height,
+                   const Option& option) {
   glGenTextures(1, &id_);
   glBindTexture(GL_TEXTURE_2D, id_);
   glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA,
@@ -88,7 +94,7 @@ void Texture::Load(const uint8_t* data, int width, int height, Option option) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, option.wrap_s);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, option.wrap_t);
   glBindTexture(GL_TEXTURE_2D, GL_NONE);
-  invalidate_texture = true;
+  g_invalidate_textures = true;
 }
 
 /// @brief Import an already loaded texture. Useful
@@ -120,7 +126,7 @@ Texture::~Texture() {
   glDeleteTextures(1, &id_);
 }
 
-Texture::Texture(Texture&& other) {
+Texture::Texture(Texture&& other) noexcept {
   operator=(std::move(other));
 }
 
@@ -128,7 +134,7 @@ Texture::Texture(const Texture& other) {
   operator=(other);
 }
 
-void Texture::operator=(Texture&& other) {
+void Texture::operator=(Texture&& other) noexcept {
   this->~Texture();
   std::swap(id_, other.id_);
   std::swap(width_, other.width_);

--- a/src/smk/Transformable.cpp
+++ b/src/smk/Transformable.cpp
@@ -26,7 +26,7 @@ void Transformable::Rotate(float rotation) {
 /// @brief Set the position of the object to be drawn.
 /// @see Transformable::Move.
 /// @param position the position (x,y) of the object.
-void Transformable::SetPosition(glm::vec2 position) {
+void Transformable::SetPosition(const glm::vec2& position) {
   position_ = position;
 }
 
@@ -41,7 +41,7 @@ void Transformable::SetPosition(float x, float y) {
 /// Increase the position of the object being drawn.
 /// @see smk::SetPosition
 /// @param move The increment of position (x,y)
-void Transformable::Move(glm::vec2 move) {
+void Transformable::Move(const glm::vec2& move) {
   position_ += move;
 }
 
@@ -57,7 +57,7 @@ void Transformable::Move(float x, float y) {
 /// center of the object will be drawn exactly on (0,0) on the screen (plus its
 /// potential translation if any)
 /// @param center The center position (x,y) in the object.
-void Transformable::SetCenter(glm::vec2 center) {
+void Transformable::SetCenter(const glm::vec2& center) {
   center_ = center;
 }
 
@@ -78,7 +78,7 @@ void Transformable::SetScale(float scale) {
 
 /// @brief Increase or decrease the size of the object being drawn.
 /// @param scale The ratio of magnification.
-void Transformable::SetScale(glm::vec2 scale) {
+void Transformable::SetScale(const glm::vec2& scale) {
   scale_ = scale;
 }
 
@@ -106,7 +106,7 @@ void Transformable::SetScaleY(float scale_y) {
 /// @return the transformation applied to the object. This is the result of
 ///         applying the translation, rotation, center and scaling to the the
 ///         object.
-glm::mat4 Transformable::Transformation() const {
+glm::mat4 Transformable::transformation() const {
   glm::mat4 ret = glm::mat4(1.0);
   ret = glm::translate(ret, {position_.x, position_.y, 0.0});
   if (rotation_ != 0.f)
@@ -145,7 +145,7 @@ void TransformableBase::SetVertexArray(VertexArray vertex_array) {
 void TransformableBase::Draw(RenderTarget& target, RenderState state) const {
   state.color *= color();
   state.texture = texture();
-  state.view *= Transformation();
+  state.view *= transformation();
   state.vertex_array = vertex_array();
   state.blend_mode = blend_mode();
   target.Draw(state);
@@ -155,11 +155,11 @@ void TransformableBase::Draw(RenderTarget& target, RenderState state) const {
 /// 4x4 matrix.
 /// @see https://learnopengl.com/Getting-started/Transformations
 /// @param transformation The 4x4 matrix defining the transformation.
-void Transformable3D::SetTransformation(const glm::mat4 transformation) {
+void Transformable3D::SetTransformation(const glm::mat4& transformation) {
   transformation_ = transformation;
 }
 
-glm::mat4 Transformable3D::Transformation() const {
+glm::mat4 Transformable3D::transformation() const {
   return transformation_;
 }
 

--- a/src/smk/VertexArray.cpp
+++ b/src/smk/VertexArray.cpp
@@ -55,7 +55,7 @@ VertexArray::VertexArray(const VertexArray& other) {
   this->operator=(other);
 }
 
-VertexArray::VertexArray(VertexArray&& other) {
+VertexArray::VertexArray(VertexArray&& other) noexcept {
   this->operator=(std::move(other));
 }
 
@@ -76,7 +76,7 @@ VertexArray& VertexArray::operator=(const VertexArray& other) {
   return *this;
 }
 
-VertexArray& VertexArray::operator=(VertexArray&& other) {
+VertexArray& VertexArray::operator=(VertexArray&& other) noexcept {
   std::swap(vbo_, other.vbo_);
   std::swap(vao_, other.vao_);
   std::swap(size_, other.size_);
@@ -102,7 +102,7 @@ VertexArray::VertexArray(const std::vector<Vertex3D>& array) {
 
 /// @brief The size of the GPU array.
 /// @return the number of vertices in the GPU array.
-int VertexArray::size() const {
+size_t VertexArray::size() const {
   return size_;
 }
 

--- a/src/smk/View.cpp
+++ b/src/smk/View.cpp
@@ -16,7 +16,7 @@ void View::SetCenter(float x, float y) {
 
 /// @brief Set the center position of the in-game view.
 /// param center The center of the view.
-void View::SetCenter(glm::vec2 center) {
+void View::SetCenter(const glm::vec2& center) {
   SetCenter(center.x, center.y);
 }
 
@@ -30,7 +30,7 @@ void View::SetSize(float width, float height) {
 
 /// @brief Set the size of the in-game view.
 /// param center The size of the view.
-void View::SetSize(glm::vec2 size) {
+void View::SetSize(const glm::vec2& size) {
   SetSize(size.x, size.y);
 }
 


### PR DESCRIPTION
I used the following chromium resources:
[style guide](https://chromium.googlesource.com/chromium/src/+/master/styleguide/c++/c++.md)
[do's and dont's](https://chromium.googlesource.com/chromium/src/+/master/styleguide/c++/c++-dos-and-donts.md)

Which are supposed to be an extension on top of Google's C++ style guide. I use this the most:
[guide](https://google.github.io/styleguide/cppguide.html#Naming)

My updates can be summarized as follows:
1. getters can be `snake_case` of the variable name (hence the trailing underscore in variable names) which looks nice
2. "Major" functions are functions that perform some action on behalf of or for the class. Well-formed major functions must have every first word capitalized
3. boolean queries are not "getters" - they are major functions so things like `IsReady()` is appropriately formed
    3.2 Functions that "GetX" something from a set of inputs were renamed to "FetchX" to avoid "getter" nomenclature. These types of functions are considered major functions since they perform actions unrelated to directly returning member values.
4. Use brace initialization where you absolutely can
5. constants _and_ enums must precede with a lower-case `k` in the name. This avoids conflicts with C macros
6. Only types with non-trivial de-constructors should be marked static in the global namespace
7. Mark functions `noexcept` where appropriate
8. API functions can be capitalized as it looks like they are "acting on" or "for" an object by design. This keeps the rest of the codebase looking consistent too.
9. Use `const type&` when passing values that do not expect a lifetime after the function because this syntax can bind to both lvalues and temporaries
10. Use `size_t` for counting or returning elements in standard library containers 
12. structs can have publicly accessible member values that do not have a trailing underscore as this library was already doing 
13. Added a `.gitignore` file for microsoft visual studio projects

Other things:
1. I fixed some spelling mistakes and translation mistakes in the codebase
2. I const-qualified functions in order to respect and make clear the intention of the function
3. I refrained from exposing pointers to internal shader programs so that they can be safely used
4. Merged with master and made sure all examples run

Bug:
1. Unsure why, but the `Text` demo with the arrow glyphs (wide char) do not render correctly anymore. Debugger shows blocks instead of arrows. It worked before and I'm unsure which commit broke it. From what I can tell, it shouldn't have been affected like that. Can you take a look at it?