### PR TITLE
[FIX] Conditional jumps and crash due to dtor call

### DIFF
--- a/src/smk/VertexArray.cpp
+++ b/src/smk/VertexArray.cpp
@@ -40,7 +40,7 @@ VertexArray::VertexArray(VertexArray&& other) noexcept {
 }
 
 VertexArray& VertexArray::operator=(const VertexArray& other) {
-  this->~VertexArray();
+  this->Release();
   if (!other.vbo_)
     return *this;
 

--- a/src/smk/VertexArray.cpp
+++ b/src/smk/VertexArray.cpp
@@ -40,7 +40,7 @@ VertexArray::VertexArray(VertexArray&& other) noexcept {
 }
 
 VertexArray& VertexArray::operator=(const VertexArray& other) {
-  this->Release();
+  Release();
   if (!other.vbo_)
     return *this;
 


### PR DESCRIPTION
This PR fix an issue found in smk-starter repository and discussed [here](https://github.com/ArthurSonzogni/smk-starter/issues/3)

To make it short, the destructor was called on `this` which indeed destruct the object itself which was  then returned. This caused multiples conditional jumps and a crash.

Fixed by changing the call to the dtor to a call to the `Release` method.

File modified : 
- VertexArray.cpp